### PR TITLE
Linux compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,39 @@ cd <to/your/lib/installation/dir>
 
 `````
 
+#### - Linux
+
+first build the latest **fluidsynth** (at the time of writing is v 2.1.6)
+
+Download sources from https://github.com/FluidSynth/fluidsynth/releases 
+
+and get the following dependencies (shown for Debian)
+
+`sudo apt install cmake libglib2.0-dev pkgconf`
+
+then `cd` to your fluidsynth sources dir an do:
+
+`````
+mkdir build
+cd build
+cmake ..
+sudo make install
+`````
+
+then `cd` to the sources of this repo and do
+
+`make install`
+
+after that run the linuxdepXX.sh script that matches the architecture of your build. This script copies fluidsynth dependencies to your fluid~ external folder. Example for 64bit:
+
+`````
+cd <to/your/fluid~/installation/dir>
+chmod 775 linuxdep64.sh
+./linuxdep64.sh
+`````
+
+Now the fluidsynth dependencies are copied to your fluid~ external folder.
+
 
 --------------------------------------------------------------------------
 

--- a/linuxdep32.sh
+++ b/linuxdep32.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+
+
+for filename in /usr/local/lib/libfluidsynth*
+do
+  cp $filename ./
+done;

--- a/linuxdep64.sh
+++ b/linuxdep64.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+
+
+for filename in /usr/local/lib64/libfluidsynth*
+do
+  cp $filename ./
+done;

--- a/makefile
+++ b/makefile
@@ -14,7 +14,26 @@ endif
 
 endef
 
-datafiles = fluid~-help.pd LICENSE.txt README.md localdeps.macos.sh
+define forLinux
+
+ifeq ($(firstword $(subst -, ,$(shell $(CC) -dumpmachine))), i686)
+	datafiles += linuxdep32.sh 
+	else
+	datafiles += linuxdep64.sh 
+endif
+
+endef
+
+define forDarwin
+
+	datafiles += localdeps.macos.sh 
+
+endef
+
+
+
+
+datafiles = fluid~-help.pd LICENSE.txt README.md 
 datadirs = sf2
 
 include pd-lib-builder/Makefile.pdlibbuilder


### PR DESCRIPTION
This PR updates the Readme with info on how to compile fluid~ for Linux.
Also includes scripts to copy dependencies to the fluid~ folder.